### PR TITLE
set expandable segments by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ Figure 1 (A) Execution time required to predict the structure of an increasing n
    ```
 
 3. **Run inference:**
-
    Run [boltz prediction](/docs/prediction.md) as usual with
    ```bash
-   export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
    boltz predict <INPUT_PATH> --use_msa_server
    ```
+> [!NOTE]
+> PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True is set internally by default unless manually specified. It can be disabled by running `export PYTORCH_CUDA_ALLOC_CONF=""`
 
 ## Options
 

--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Literal, Optional
 
 import click
+if "PYTORCH_CUDA_ALLOC_CONF" not in os.environ:                                                                    
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 import torch
 from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.strategies import DDPStrategy


### PR DESCRIPTION
Set PYTORCH_CUDA_ALLOC_CONF environment variable by default to optimise for memory use.