### PR TITLE
fix affinity prediction

### DIFF
--- a/src/boltz/main.py
+++ b/src/boltz/main.py
@@ -1303,8 +1303,9 @@ def predict(  # noqa: C901, PLR0915, PLR0912
             "chunk_size_transition_z": chunk_size_transition_z,
             "chunk_size_transition_msa": chunk_size_transition_msa,
             "chunk_size_outer_product": chunk_size_outer_product,
-            "triangle_mult_gate_nchunks": triangle_mult_gate_nchunks,
-            "chunk_size_tri_attn": chunk_size_tri_attn
+            "chunk_size_tri_attn": chunk_size_tri_attn,
+            "chunk_size_threshold": chunk_size_threshold,
+            "triangle_mult_gate_nchunks": triangle_mult_gate_nchunks
         }
 
         # Load affinity model

--- a/src/boltz/model/modules/affinity.py
+++ b/src/boltz/model/modules/affinity.py
@@ -101,13 +101,13 @@ class AffinityModule(nn.Module):
             BM, N, _ = x_pred.shape
             B = BM // multiplicity
             mult = multiplicity
-        x_pred_repr = torch.bmm(token_to_rep_atom.float(), x_pred)
+        x_pred_repr = torch.bmm(token_to_rep_atom.cuda().float(), x_pred)
         d = torch.cdist(x_pred_repr, x_pred_repr)
 
         distogram = (d.unsqueeze(-1) > self.boundaries).sum(dim=-1).long()
         distogram = self.dist_bin_pairwise_embed(distogram)
 
-        z = z + self.pairwise_conditioner(z_trunk=z, token_rel_pos_feats=distogram)
+        z = z + self.pairwise_conditioner(z_trunk={"key": z}, token_rel_pos_feats={"key": distogram})
 
         pad_token_mask = feats["token_pad_mask"].repeat_interleave(multiplicity, 0)
         rec_mask = (feats["mol_type"] == 0).repeat_interleave(multiplicity, 0)

--- a/src/boltz/model/modules/encodersv2.py
+++ b/src/boltz/model/modules/encodersv2.py
@@ -323,10 +323,10 @@ class AtomEncoder(Module):
             atom_feats = [
                 atom_ref_pos,
                 feats["ref_charge"].unsqueeze(-1),
-                feats["ref_element"],
+                feats["ref_element"].cuda(),
             ]
             if not self.use_no_atom_char:
-                atom_feats.append(feats["ref_atom_name_chars"].reshape(B, N, 4 * 64))
+                atom_feats.append(feats["ref_atom_name_chars"].reshape(B, N, 4 * 64).cuda())
             if self.use_atom_backbone_feat:
                 atom_feats.append(feats["atom_backbone_feat"])
             if self.use_residue_feats_atoms:


### PR DESCRIPTION
Fix several bugs for affinity prediction:

- device placement of features.
- missing chunk_size_threshold parameter.
- make compatible with dictionary scope management hack in pairwise_conditioner.